### PR TITLE
Some usability improvements

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,48 @@
+[
+	{
+		"caption": "Preferences",
+		"id": "preferences",
+		"mnemonic": "n",
+		"children":
+		[
+			{
+				"caption": "Package Settings",
+				"id": "package-settings",
+				"mnemonic": "P",
+				"children":
+				[
+					{
+						"caption": "SublimeStackIDE",
+						"children":
+						[
+							{
+								"caption": "README",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/SublimeStackIDE/README.md"
+								}
+							},
+							{
+								"caption": "-"
+							},
+							{
+								"caption": "Settings – Default",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/SublimeStackIDE/SublimeStackIDE.sublime-settings"
+								}
+							},
+							{
+								"caption": "Settings – User",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/User/SublimeStackIDE.sublime-settings"
+								}
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+]

--- a/SublimeStackIDE.sublime-settings
+++ b/SublimeStackIDE.sublime-settings
@@ -1,0 +1,8 @@
+{
+  // List of directories to add to the default system path when running 'stack'.
+   "add_to_PATH": []
+
+  // Controls the messages sent to the console.
+  // Possible values: "none", "error", "warning", "normal", "debug".
+  ,"verbosity": "warning" 
+}


### PR DESCRIPTION
Some changes that have to do with installation, error reporting, configuration and robustness.  The main new features are:
- Adds plugin settings, accessible from `Preferences -> Package Settings`. Changes to settings are dynamically reflected on the plugin.
- Logging to the console is controlled by a `verbosity` setting.
- An `add_to_PATH` setting allows the user to give the location of the `stack` and `stack-ide`. This is particularly useful on OS X, since programs lauched from the dock, spotlight, etc, get the system PATH but not whatever the user sets via `~/.profile` (before this, I could only start Sublime from a terminal with `subl`)
- When `stack` is not found on the path, a pop up informs the user of the situation, suggests setting `add_to_PATH`, etc. (it is not shown again unless the user changes the settings).
- `SendStackIdeRequestCommand.__init__()` is no longer used to launch a `stack-ide` instance and kick off the process. Instead, we rely on the watchdog to call `StackIde.check_windows()` periodically. This method initializes new windows and ends the sessions of those windows no longer open. This way we can have the plugin (re-)trying to start the instances when the path changes, etc.
