### PR TITLE
Better type info + type popup

### DIFF
--- a/SublimeStackIDE.sublime-settings
+++ b/SublimeStackIDE.sublime-settings
@@ -4,5 +4,9 @@
 
   // Controls the messages sent to the console.
   // Possible values: "none", "error", "warning", "normal", "debug".
-  ,"verbosity": "warning" 
+  ,"verbosity": "warning"
+
+  // If "show_popup" is true, a popup will appear right below selection
+  // to show the type in addition to the text shown in the status bar
+  ,"show_popup": false
 }

--- a/stack-ide.py
+++ b/stack-ide.py
@@ -569,7 +569,8 @@ class StackIDE:
                 types)[0]
             span = Span.from_json(type_span, self.window)
             if span:
-                view.show_popup(type_string) #types.join("<br>"))
+                if Settings.show_popup():
+                    view.show_popup(type_string)
                 view.set_status("type_at_cursor", type_string)
                 view.add_regions("type_at_cursor", [span.region], "storage.type", "", sublime.DRAW_OUTLINED)
         else:
@@ -767,6 +768,11 @@ class Settings:
         val = cls._get("add_to_PATH", [])
         if not isinstance(val,list):
             val = []
+        return val
+
+    @classmethod
+    def show_popup(cls):
+        val = cls._get("show_popup", False)
         return val
 
     @classmethod

--- a/stack-ide.py
+++ b/stack-ide.py
@@ -541,7 +541,6 @@ class StackIDE:
         self.window.run_command("update_completions", {"completions":completions})
 
     def filter_enclosing(_,from_col, to_col, from_line, to_line, spans):
-        # return spans
         return [span for span in spans if 
             (   ((span[1].get("spanFromLine")<from_line) or 
                 (span[1].get("spanFromLine") == from_line and


### PR DESCRIPTION
2 new features:
- clever type info: (show the most relevant type information possible)
- visual popup right below text selection (enable / disable via config file)

example 1:

<img width="425" alt="capture d ecran 2015-07-29 a 13 16 35" src="https://cloud.githubusercontent.com/assets/2150990/8956263/403654d8-35f4-11e5-8b54-0ae6391dd0bf.png">
<img width="317" alt="capture d ecran 2015-07-29 a 13 16 41" src="https://cloud.githubusercontent.com/assets/2150990/8956262/4034584a-35f4-11e5-85ad-cbb2c7463d82.png">
<img width="263" alt="capture d ecran 2015-07-29 a 13 16 47" src="https://cloud.githubusercontent.com/assets/2150990/8956264/4036df5c-35f4-11e5-9108-d2bd8b67679d.png">
<img width="266" alt="capture d ecran 2015-07-29 a 13 17 00" src="https://cloud.githubusercontent.com/assets/2150990/8956261/40321792-35f4-11e5-8e77-7e8f479e081a.png">

Example 2:

<img width="295" alt="capture d ecran 2015-07-28 a 13 40 01" src="https://cloud.githubusercontent.com/assets/2150990/8956229/ed26f66c-35f3-11e5-82be-eab203fc1083.png">
<img width="258" alt="capture d ecran 2015-07-28 a 13 39 45" src="https://cloud.githubusercontent.com/assets/2150990/8956230/ed2aaa3c-35f3-11e5-816c-983b96018788.png">
<img width="256" alt="capture d ecran 2015-07-28 a 13 39 40" src="https://cloud.githubusercontent.com/assets/2150990/8956232/ed2b2bec-35f3-11e5-920e-1dea3c369093.png">
<img width="260" alt="capture d ecran 2015-07-28 a 13 39 32" src="https://cloud.githubusercontent.com/assets/2150990/8956231/ed2aee2a-35f3-11e5-94c5-927a0f24ee6c.png">

(ps: I don't usually write python, so it may not be idiomatic code. I just wanted those features enough to give it a go)
