### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sublime Text plugin for [stack-ide](https://github.com/commercialhaskell/stack-ide)
 
 **Bleeding edge note:** 
-Requires `stack` 0.1.2+, `stack-ide` 0.1+, `ide-backend` HEAD and GHC 7.10+.
+Requires `stack` 0.1.4+, `stack-ide` 0.1+, `ide-backend` HEAD and GHC 7.10+.
 
 `stack-ide-sublime` also requires for the moment that you are opening the same folder that holds the `.cabal` file, and that the folder is named the same as the `.cabal` file.
 
@@ -13,10 +13,10 @@ First make sure to install [stack](https://github.com/commercialhaskell/stack#us
 and [stack-ide](https://github.com/commercialhaskell/stack-ide).
 
 **On OSX** install this package with the following command:
-`(cd "~/Library/Application Support/Sublime Text 3/Packages"; git clone https://github.com/lukexi/stack-ide-sublime.git)`
+`(cd "~/Library/Application Support/Sublime Text 3/Packages"; git clone https://github.com/lukexi/stack-ide-sublime.git SublimeStackIDE)`
 
 **On Linux** install this package with the following command:
-`(cd ~/.config/sublime-text-3/Packages; git clone https://github.com/lukexi/stack-ide-sublime.git)`
+`(cd ~/.config/sublime-text-3/Packages; git clone https://github.com/lukexi/stack-ide-sublime.git  SublimeStackIDE)`
 
 
 ### Screenshots
@@ -26,5 +26,26 @@ and [stack-ide](https://github.com/commercialhaskell/stack-ide).
 ![SublimeStackIDE Type-at-cursor](http://lukexi.github.io/RawhideTypeAtCursor.png)
 
 
+### Tips
+
+#### Hide stack-ide generated folders from Sublime Text
+
+Add the following to your global User Preferences *(Sublime Text -> Preferences -> Settings - User)*:
+
+`"folder_exclude_patterns": [".stack-work", "session.*"],`
+
+
 ### Troubleshooting
+
 First check the Sublime Text console with `ctrl-``. You can increase the plugin's log level by changing the "verbosity" setting in SublimeStackIDE.sublime-settings to "debug". Let us know what you see and we'll get it fixed.
+
+#### Known issues
+
+##### Not working in executable targets
+
+Add modules (eg. Main) to the executable target's `other_modules` list in the cabal file. (see https://github.com/commercialhaskell/stack-ide/issues/28)
+
+##### Error "can't find file: /Users/myself/first-project/Lib" in the console
+
+This was a problem in stack 1.3, upgrade to a newer version (see: https://github.com/lukexi/stack-ide-sublime/issues/13)
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ First check the Sublime Text console with `ctrl-``. You can increase the plugin'
 
 ##### Not working in executable targets
 
-Add modules (eg. Main) to the executable target's `other_modules` list in the cabal file. (see https://github.com/commercialhaskell/stack-ide/issues/28)
+Add modules (eg. Main) to the executable target's `other_modules` list in the cabal file. After restarting Stack IDE you should see the listed modules being compiled (see https://github.com/commercialhaskell/stack-ide/issues/28)
 
 ##### Error "can't find file: /Users/myself/first-project/Lib" in the console
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and [stack-ide](https://github.com/commercialhaskell/stack-ide).
 
 Add the following to your global User Preferences *(Sublime Text -> Preferences -> Settings - User)*:
 
-`"folder_exclude_patterns": [".stack-work", "session.*"],`
+`"folder_exclude_patterns": [".git", ".svn", "CVS", ".stack-work", "session.*"],`
 
 
 ### Troubleshooting


### PR DESCRIPTION
A few updates to the documentation:

The issue with loading non-existing files (https://github.com/lukexi/stack-ide-sublime/issues/13) seems to be fixed by installing a newer version (1.4+) of stack (and stack-ide)

Specify `SublimeStackIDE` as destination path when cloning, this fixes Sublime's menu links to the Default and User package settings.

A temporary fix for getting stack-ide to load executable targets was found in https://github.com/commercialhaskell/stack-ide/issues/28 

I also added @rvion's suggestion (https://github.com/lukexi/stack-ide-sublime/issues/11) to hide the generated folders.
