### PR TITLE
Extract parsing logic with testing, add coverage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ __pycache__
 htmlcov
 *.log
 *.coverage
+.stack-work
+*.sublime-workspace
 autocomplete-output.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install coveralls
 
 # command to run tests
-script: coverage run --omit="test/*" -m unittest
+script: coverage run --source="." --omit="test/*" -m unittest
 
 # publish results
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ python:
   - "3.4"
 
 # command to install dependencies
-install: ""
+install:
+  - pip install coverage
+  - pip install coveralls
 
 # command to run tests
-script: python -m unittest -v
+script: coverage run --omit="test/*" -m unittest
+
+# publish results
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 ![build status](https://travis-ci.org/lukexi/stack-ide-sublime.svg)
+[![Coverage Status](https://coveralls.io/repos/tomv564/stack-ide-sublime/badge.svg?branch=extract_parsing&service=github)](https://coveralls.io/github/tomv564/stack-ide-sublime?branch=extract_parsing)
 
 # stack-ide-sublime
 

--- a/mocks/sublime.py
+++ b/mocks/sublime.py
@@ -1,0 +1,79 @@
+import uuid
+
+current_status = ""
+current_error = ""
+
+def status_message(msg):
+    global current_status
+    current_status = msg
+
+def error_message(msg):
+    global current_error
+    current_error = msg
+
+def set_timeout_async(fn, delay):
+    pass
+
+def set_timeout(fn, delay):
+    fn()
+
+def load_settings(name):
+    return Settings()
+
+class Settings():
+
+    def add_on_change(self, key, func):
+        pass
+
+    def get(self, key, default):
+        return default
+
+
+# class FakeBackend():
+
+
+
+class FakeWindow():
+
+    def __init__(self, folder):
+        self._folders = [folder]
+        self._id = uuid.uuid4()
+
+    def id(self):
+        return self._id
+
+    def folders(self):
+        return self._folders
+
+fake_windows = []
+
+ENCODED_POSITION = 1 #flag used for window.open_file
+DRAW_OUTLINED = 2 # flag used for view.add_regions
+
+clipboard = None
+
+def create_window(path):
+    global fake_windows
+    window = FakeWindow(path)
+    fake_windows.append(window)
+    return window
+
+def destroy_windows():
+    global fake_windows
+    fake_windows = []
+
+def set_clipboard(text):
+    global clipboard
+    clipboard = text
+
+def windows():
+    global fake_windows
+    return fake_windows
+
+class Region():
+
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+

--- a/mocks/sublime_plugin.py
+++ b/mocks/sublime_plugin.py
@@ -1,0 +1,21 @@
+# import mock
+
+class TextCommand():
+
+    def __init__(self):
+        pass
+
+class EventListener():
+
+    def __init__(self):
+        pass
+
+class WindowCommand():
+
+    def __init__(self):
+        pass
+
+class ApplicationCommand():
+
+    def __init__(self):
+        pass

--- a/response.py
+++ b/response.py
@@ -1,0 +1,174 @@
+#############################################
+# PARSING
+#
+# see: https://github.com/commercialhaskell/stack-ide/blob/master/stack-ide-api/src/Stack/Ide/JsonAPI.hs
+# and: https://github.com/fpco/ide-backend/blob/master/ide-backend-common/IdeSession/Types/Public.hs
+# Types of responses:
+# ResponseGetSourceErrors [SourceError]
+# ResponseGetLoadedModules [ModuleName]
+# ResponseGetSpanInfo [ResponseSpanInfo]
+# ResponseGetExpTypes [ResponseExpType]
+# ResponseGetAnnExpTypes [ResponseAnnExpType]
+# ResponseGetAutocompletion [IdInfo]
+# ResponseUpdateSession
+# ResponseLog
+
+def parse_autocompletions(contents):
+    """
+    Converts ResponseGetAutoCompletion content into [(IdProp, IdScope)]
+    """
+    return ((parse_idprop(item.get('idProp')),
+            parse_idscope(item.get('idScope'))) for item in contents)
+
+
+def parse_update_session(contents):
+    """
+    Converts a ResponseUpdateSession message to a single status string
+    """
+    tag = contents.get('tag')
+    if tag == "UpdateStatusProgress":
+        progress = contents.get('contents')
+        return str(progress.get("progressParsedMsg"))
+    elif tag == "UpdateStatusDone":
+        return "Session started."
+    elif tag == "UpdateStatusRequiredRestart":
+        return "Restarting session..."
+
+
+def parse_source_errors(contents):
+    """
+    Converts ResponseGetSourceErrors content into an array of SourceError objects
+    """
+    return (SourceError(item.get('errorKind'),
+                        item.get('errorMsg'),
+                        parse_either_span(item.get('errorSpan'))) for item in contents)
+
+
+def parse_exp_types(contents):
+    """
+    Converts ResponseGetExpTypes contents into an array of pairs containing
+    Text and SourceSpan
+    Also see: type_info_for_sel (replace)
+    """
+    return ((item[0], parse_source_span(item[1])) for item in contents)
+
+
+def parse_span_info_response(contents):
+    """
+    Converts ResponseGetSpanInfo contents into an array of pairs of SpanInfo and SourceSpan objects
+    ResponseGetSpanInfo's contents are an array of SpanInfo and SourceSpan pairs
+    """
+    return ((parse_span_info(responseSpanInfo[0]),
+             parse_source_span(responseSpanInfo[1])) for responseSpanInfo in contents)
+
+
+def parse_span_info(json):
+    """
+    Converts SpanInfo contents into a pair of IdProp and IdScope objects
+
+    :param dict json: responds to a Span type from Stack IDE
+
+    SpanInfo is either 'tag' SpanId or 'tag' SpanQQ, with an nested under as contents IdInfo
+    TODO: deal with SpanQQ here
+    """
+    contents = json.get('contents')
+    return (parse_idprop(contents.get('idProp')),
+            parse_idscope(contents.get('idScope')))
+
+
+def parse_idprop(values):
+    """
+    Converts idProp content into an IdProp object.
+    """
+    return IdProp(values.get('idDefinedIn').get('moduleName'),
+                    values.get('idDefinedIn').get('modulePackage').get('packageName'),
+                    values.get('idType'),
+                    values.get('idName'),
+                    parse_either_span(values.get('idDefSpan')))
+
+
+def parse_idscope(values):
+    """
+    Converts idScope content into an IdScope object (containing only an IdImportedFrom)
+    """
+    importedFrom = values.get('idImportedFrom')
+    return IdScope(IdImportedFrom(importedFrom.get('moduleName'),
+                                  importedFrom.get('modulePackage').get('packageName'))) if importedFrom else None
+
+
+def parse_either_span(json):
+    """
+    Checks EitherSpan content and returns a SourceSpan if possible.
+    """
+    if json.get('tag') == 'ProperSpan':
+        return parse_source_span(json.get('contents'))
+    else:
+        return None
+
+
+def parse_source_span(json):
+    """
+    Converts json into a SourceSpan
+    """
+    paths = ['spanFilePath', 'spanFromLine', 'spanFromColumn', 'spanToLine', 'spanToColumn']
+    fields = get_paths(paths, json)
+    return SourceSpan(*fields) if fields else None
+
+
+def get_paths(paths, values):
+    """
+    Converts a list of keypaths into an array of values from a dict
+    """
+    return list(values.get(path) for path in paths)
+
+
+class SourceError():
+
+    def __init__(self, kind, message, span):
+        self.kind = kind
+        self.msg = message
+        self.span = span
+
+    def __repr__(self):
+        if self.span:
+            return "{file}:{from_line}:{from_column}: {kind}:\n{msg}".format(
+                file=self.span.filePath,
+                from_line=self.span.fromLine,
+                from_column=self.span.fromColumn,
+                kind=self.kind,
+                msg=self.msg)
+        else:
+            return self.msg
+
+
+class SourceSpan():
+
+    def __init__(self, filePath, fromLine, fromColumn, toLine, toColumn):
+        self.filePath = filePath
+        self.fromLine = fromLine
+        self.fromColumn = fromColumn
+        self.toLine = toLine
+        self.toColumn = toColumn
+
+
+class IdScope():
+
+    def __init__(self, importedFrom):
+        self.importedFrom = importedFrom
+
+
+class IdImportedFrom():
+
+    def __init__(self, module, package):
+        self.module = module
+        self.package = package
+
+
+class IdProp():
+
+    def __init__(self, package, module, type, name, defSpan):
+        self.package = package
+        self.module = module
+        self.type = type
+        self.name = name
+        self.defSpan = defSpan

--- a/test/stubs/sublime.py
+++ b/test/stubs/sublime.py
@@ -29,10 +29,6 @@ class Settings():
         return default
 
 
-# class FakeBackend():
-
-
-
 class FakeWindow():
 
     def __init__(self, folder):
@@ -75,5 +71,3 @@ class Region():
     def __init__(self, start, end):
         self.start = start
         self.end = end
-
-

--- a/test/stubs/sublime_plugin.py
+++ b/test/stubs/sublime_plugin.py
@@ -1,4 +1,3 @@
-# import mock
 
 class TextCommand():
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,0 +1,137 @@
+import unittest
+from unittest.mock import MagicMock, Mock, ANY
+
+# import text_commands
+
+# class CommandTests(unittest.TestCase):
+
+#     def test_can_clear_panel(self):
+#         cmd = text_commands.ClearErrorPanelCommand()
+#         cmd.view = MagicMock()
+#         cmd.run(None)
+#         cmd.view.erase.assert_called_with(ANY, ANY)
+
+#     def test_can_update_panel(self):
+#         cmd = text_commands.UpdateErrorPanelCommand()
+#         cmd.view = MagicMock()
+#         cmd.view.size = Mock(return_value=0)
+#         cmd.run(None, 'message')
+#         cmd.view.insert.assert_called_with(ANY, 0, "message\n\n")
+
+    # def test_can_show_type_at_cursor(self):
+    #     cmd = stackide.ShowHsTypeAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+    #     type_info = "YOLO -> Ded"
+    #     span = {
+    #         # "spanFilePath": relative_view_file_name(view),
+    #         "spanFromLine": 1,
+    #         "spanFromColumn": 1,
+    #         "spanToLine": 1,
+    #         "spanToColumn": 5
+    #     }
+
+    #     response = {"tag": "", "contents": [[type_info, span]]}
+    #     backend = FakeBackend(response)
+    #     instance = stackide.StackIDE(cmd.view.window(), backend)
+    #     backend.handler = instance.handle_response
+    #     stackide.supervisor = stackide.Supervisor(monitor=False)
+    #     stackide.supervisor.window_instances[
+    #         cmd.view.window().id()] = instance
+
+    #     cmd.run(None)
+    #     cmd.view.show_popup.assert_called_with(type_info)
+    #     stackide.supervisor = None
+
+    # def test_can_copy_type_at_cursor(self):
+    #     cmd = stackide.CopyHsTypeAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+    #     type_info = "YOLO -> Ded"
+    #     span = {
+    #         # "spanFilePath": relative_view_file_name(view),
+    #         "spanFromLine": 1,
+    #         "spanFromColumn": 1,
+    #         "spanToLine": 1,
+    #         "spanToColumn": 5
+    #     }
+
+    #     response = {"tag": "", "contents": [[type_info, span]]}
+    #     backend = FakeBackend(response)
+    #     instance = stackide.StackIDE(cmd.view.window(), backend)
+    #     backend.handler = instance.handle_response
+
+    #     stackide.supervisor = stackide.Supervisor(monitor=False)
+    #     stackide.supervisor.window_instances[
+    #         cmd.view.window().id()] = instance
+
+    #     cmd.run(None)
+    #     self.assertEqual(sublime.clipboard, type_info)
+    #     stackide.supervisor = None
+
+    # def test_can_request_show_info_at_cursor(self):
+    #     cmd = stackide.ShowHsInfoAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+
+    #     # response = {"tag": "", "contents": [[{"contents" : someFunc_span_info}, {}]]}
+    #     backend = FakeBackend(someFunc_span_info)
+    #     instance = stackide.StackIDE(cmd.view.window(), backend)
+    #     backend.handler = instance.handle_response
+
+    #     stackide.supervisor = stackide.Supervisor(monitor=False)
+    #     stackide.supervisor.window_instances[
+    #         cmd.view.window().id()] = instance
+
+    #     cmd.run(None)
+    #     cmd.view.show_popup.assert_called_with("someFunc :: IO ()  (Defined in src/Lib.hs:9:1)")
+    #     stackide.supervisor = None
+
+    # def test_show_info_from_module(self):
+    #     cmd = stackide.ShowHsInfoAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+    #     # response = {"tag": "", "contents": [[{"contents" : putStrLn_span_info}, {}]]}
+    #     backend = FakeBackend(putStrLn_span_info)
+    #     instance = stackide.StackIDE(cmd.view.window(), backend)
+    #     backend.handler = instance.handle_response
+
+    #     stackide.supervisor = stackide.Supervisor(monitor=False)
+    #     stackide.supervisor.window_instances[
+    #         cmd.view.window().id()] = instance
+
+    #     cmd.run(None)
+    #     cmd.view.show_popup.assert_called_with("putStrLn :: String -> IO ()  (Imported from Prelude)")
+    #     stackide.supervisor = None
+
+    # def test_goto_definition_at_cursor(self):
+    #     global cur_dir
+    #     cmd = stackide.GotoDefinitionAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+    #     backend = FakeBackend(someFunc_span_info)
+    #     window = cmd.view.window()
+    #     window.open_file = Mock()
+    #     instance = stackide.StackIDE(window, backend)
+    #     backend.handler = instance.handle_response
+
+    #     stackide.supervisor = stackide.Supervisor(monitor=False)
+    #     stackide.supervisor.window_instances[
+    #         cmd.view.window().id()] = instance
+
+    #     cmd.run(None)
+    #     window.open_file.assert_called_with(cur_dir + "/mocks/helloworld/src/Lib.hs:9:1", sublime.ENCODED_POSITION)
+    #     stackide.supervisor = None
+
+    # def test_goto_definition_of_module(self):
+    #     global cur_dir
+    #     cmd = stackide.GotoDefinitionAtCursorCommand()
+    #     cmd.view = mock_view()
+    #     cmd.view.show_popup = Mock()
+    #     window = cmd.view.window()
+    #     window.status_message = Mock()
+    #     cmd._handle_response(putStrLn_span_info.get('contents'))
+    #     self.assertEqual("Cannot navigate to putStrLn, it is imported from Prelude", sublime.current_status)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1,0 +1,65 @@
+import unittest
+import response as res
+
+source_errors = {'seq': 'd0599c00-0b77-441c-8947-b3882cab298c', 'tag': 'ResponseGetSourceErrors', 'contents': [{'errorSpan': {'tag': 'ProperSpan', 'contents': {'spanFromColumn': 22, 'spanFromLine': 11, 'spanFilePath': 'src/Lib.hs', 'spanToColumn': 28, 'spanToLine': 11}}, 'errorKind': 'KindError', 'errorMsg': 'Couldn\'t match expected type ‘Integer’ with actual type ‘[Char]’\nIn the first argument of ‘greet’, namely ‘"You!"’\nIn the second argument of ‘($)’, namely ‘greet "You!"’\nIn a stmt of a \'do\' block: putStrLn $ greet "You!"'}, {'errorSpan': {'tag': 'ProperSpan', 'contents': {'spanFromColumn': 24, 'spanFromLine': 15, 'spanFilePath': 'src/Lib.hs', 'spanToColumn': 25, 'spanToLine': 15}}, 'errorKind': 'KindError', 'errorMsg': 'Couldn\'t match expected type ‘[Char]’ with actual type ‘Integer’\nIn the second argument of ‘(++)’, namely ‘s’\nIn the expression: "Hello, " ++ s'}]}
+many_completions = {'tag': 'ResponseGetAutocompletion', 'contents': [{'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.List', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'GHC.OldList', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '!!', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Data.List', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 4, 'spanToLine': 4, 'spanFromColumn': 1, 'spanToColumn': 17}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Base', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Data.Function', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': '(a -> b) -> a -> b', 'idName': '$', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<wired into compiler>'}}, 'idScope': {'tag': 'WiredIn', 'contents': []}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Base', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '$!', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Classes', 'modulePackage': {'packageName': 'ghc-prim', 'packageKey': 'ghc-prim', 'packageVersion': '0.4.0.0'}}, 'idHomeModule': {'moduleName': 'Data.Bool', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '&&', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Num', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '*', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Float', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '**', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Base', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Control.Applicative', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '*>', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}, {'idProp': {'idSpace': 'VarName', 'idDefinedIn': {'moduleName': 'GHC.Num', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idHomeModule': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idType': None, 'idName': '+', 'idDefSpan': {'tag': 'TextSpan', 'contents': '<no location info>'}}, 'idScope': {'tag': 'Imported', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageName': 'base', 'packageKey': 'base', 'packageVersion': '4.8.1.0'}}, 'idImportSpan': {'tag': 'ProperSpan', 'contents': {'spanFilePath': 'app/Main.hs', 'spanFromLine': 1, 'spanToLine': 1, 'spanFromColumn': 1, 'spanToColumn': 1}}, 'idImportQual': ''}}]}
+someFunc_span_info = {'contents': [[{'contents': {'idProp': {'idDefinedIn': {'moduleName': 'Lib', 'modulePackage': {'packageVersion': None, 'packageName': 'main', 'packageKey': 'main'}}, 'idSpace': 'VarName', 'idType': 'IO ()', 'idDefSpan': {'contents': {'spanFromLine': 9, 'spanFromColumn': 1, 'spanToColumn': 9, 'spanFilePath': 'src/Lib.hs', 'spanToLine': 9}, 'tag': 'ProperSpan'}, 'idName': 'someFunc', 'idHomeModule': None}, 'idScope': {'idImportQual': '', 'idImportedFrom': {'moduleName': 'Lib', 'modulePackage': {'packageVersion': None, 'packageName': 'main', 'packageKey': 'main'}}, 'idImportSpan': {'contents': {'spanFromLine': 3, 'spanFromColumn': 1, 'spanToColumn': 11, 'spanFilePath': 'app/Main.hs', 'spanToLine': 3}, 'tag': 'ProperSpan'}, 'tag': 'Imported'}}, 'tag': 'SpanId'}, {'spanFromLine': 7, 'spanFromColumn': 27, 'spanToColumn': 35, 'spanFilePath': 'app/Main.hs', 'spanToLine': 7}]], 'seq': '724752c9-a7bf-4658-834a-3ff7df64e7e5', 'tag': 'ResponseGetSpanInfo'}
+putStrLn_span_info = {'contents': [[{'contents': {'idProp': {'idDefinedIn': {'moduleName': 'System.IO', 'modulePackage': {'packageVersion': '4.8.1.0', 'packageName': 'base', 'packageKey': 'base'}}, 'idSpace': 'VarName', 'idType': 'String -> IO ()', 'idDefSpan': {'contents': '<no location info>', 'tag': 'TextSpan'}, 'idName': 'putStrLn', 'idHomeModule': {'moduleName': 'System.IO', 'modulePackage': {'packageVersion': '4.8.1.0', 'packageName': 'base', 'packageKey': 'base'}}}, 'idScope': {'idImportQual': '', 'idImportedFrom': {'moduleName': 'Prelude', 'modulePackage': {'packageVersion': '4.8.1.0', 'packageName': 'base', 'packageKey': 'base'}}, 'idImportSpan': {'contents': {'spanFromLine': 1, 'spanFromColumn': 8, 'spanToColumn': 12, 'spanFilePath': 'app/Main.hs', 'spanToLine': 1}, 'tag': 'ProperSpan'}, 'tag': 'Imported'}}, 'tag': 'SpanId'}, {'spanFromLine': 7, 'spanFromColumn': 41, 'spanToColumn': 49, 'spanFilePath': 'app/Main.hs', 'spanToLine': 7}]], 'seq': '6ee8d949-82bd-491d-8b79-ffcaa3e65fde', 'tag': 'ResponseGetSpanInfo'}
+readFile_exp_types = {'tag': 'ResponseGetExpTypes', 'contents': [['FilePath -> IO String', {'spanToColumn': 25, 'spanToLine': 10, 'spanFromColumn': 17, 'spanFromLine': 10, 'spanFilePath': 'src/Lib.hs'}], ['IO String', {'spanToColumn': 36, 'spanToLine': 10, 'spanFromColumn': 17, 'spanFromLine': 10, 'spanFilePath': 'src/Lib.hs'}], ['IO ()', {'spanToColumn': 28, 'spanToLine': 11, 'spanFromColumn': 12, 'spanFromLine': 9, 'spanFilePath': 'src/Lib.hs'}]], 'seq': 'fd3eb2a5-e390-4ad7-be72-8b2e82441a95'}
+status_progress_restart = {'contents': {'contents': [], 'tag': 'UpdateStatusRequiredRestart'}, 'tag': 'ResponseUpdateSession'}
+status_progress_1 = {'contents': {'contents': {'progressParsedMsg': 'Compiling Lib', 'progressNumSteps': 2, 'progressStep': 1, 'progressOrigMsg': '[1 of 2] Compiling Lib              ( /Users/tomv/Projects/Personal/haskell/helloworld/src/Lib.hs, interpreted )'}, 'tag': 'UpdateStatusProgress'}, 'tag': 'ResponseUpdateSession'}
+status_progress_2 = {'contents': {'contents': {'progressParsedMsg': 'Compiling Main', 'progressNumSteps': 2, 'progressStep': 2, 'progressOrigMsg': '[2 of 2] Compiling Main             ( /Users/tomv/Projects/Personal/haskell/helloworld/app/Main.hs, interpreted )'}, 'tag': 'UpdateStatusProgress'}, 'tag': 'ResponseUpdateSession'}
+status_progress_done = {'contents': {'contents': [], 'tag': 'UpdateStatusDone'}, 'tag': 'ResponseUpdateSession'}
+
+
+class ParsingTests(unittest.TestCase):
+
+    def test_parse_source_errors_empty(self):
+        errors = res.parse_source_errors([])
+        self.assertEqual(0, len(list(errors)))
+
+    def test_parse_source_errors_error(self):
+        errors = list(res.parse_source_errors(source_errors.get('contents')))
+        self.assertEqual(2, len(errors))
+        err1, err2 = errors
+        self.assertEqual(err1.kind, 'KindError')
+        self.assertRegex(err1.msg, "Couldn\'t match expected type ‘Integer’")
+        self.assertEqual(err1.span.filePath, 'src/Lib.hs')
+        self.assertEqual(err1.span.fromLine, 11)
+        self.assertEqual(err1.span.fromColumn, 22)
+
+        self.assertEqual(err2.kind, 'KindError')
+        self.assertRegex(err2.msg, "Couldn\'t match expected type ‘\[Char\]’")
+        self.assertEqual(err2.span.filePath, 'src/Lib.hs')
+        self.assertEqual(err2.span.fromLine, 15)
+        self.assertEqual(err2.span.fromColumn, 24)
+
+    def test_parse_exp_types_empty(self):
+        exp_types = res.parse_exp_types([])
+        self.assertEqual(0, len(list(exp_types)))
+
+    def test_parse_exp_types_readFile(self):
+        exp_types = list(res.parse_exp_types(readFile_exp_types.get('contents')))
+        self.assertEqual(3, len(exp_types))
+        (type, span) = exp_types[0]
+
+        self.assertEqual('FilePath -> IO String', type)
+        self.assertEqual('src/Lib.hs', span.filePath)
+
+    def test_parse_completions_empty(self):
+        self.assertEqual([], list(res.parse_autocompletions([])))
+
+    def test_parse_completions(self):
+        completions = list(res.parse_autocompletions(many_completions.get('contents')))
+        self.assertEqual(8, len(completions))
+        (prop, scope) = completions[0]
+        self.assertEqual('!!', prop.name)
+        self.assertEqual(None, prop.type)
+        self.assertEqual('Data.List', scope.importedFrom.module)
+
+    def test_parse_update_session(self):
+
+        self.assertEqual('Restarting session...', res.parse_update_session(status_progress_restart.get('contents')))
+        self.assertEqual('Compiling Lib', res.parse_update_session(status_progress_1.get('contents')))
+        self.assertEqual('Compiling Main', res.parse_update_session(status_progress_2.get('contents')))
+        self.assertEqual('Session started.', res.parse_update_session(status_progress_done.get('contents')))

--- a/utility.py
+++ b/utility.py
@@ -3,7 +3,7 @@ import os
 try:
     import sublime
 except ImportError:
-    import mocks.sublime as sublime
+    import test.stubs.sublime as sublime
 
 def first_folder(window):
     """

--- a/utility.py
+++ b/utility.py
@@ -1,5 +1,10 @@
 import glob
 import os
+try:
+    import sublime
+except ImportError:
+    import mocks.sublime as sublime
+
 def first_folder(window):
     """
     We only support running one stack-ide instance per window currently,
@@ -46,6 +51,19 @@ def get_window(view_or_window):
 def span_from_view_selection(view):
     return span_from_view_region(view, view.sel()[0])
 
+def view_region_from_span(view, span):
+    """
+    Maps a SourceSpan to a Region for a given view.
+
+    :param sublime.View view: The view to create regions for
+    :param SourceSpan span: The span to map to a region
+    :rtype sublime.Region: The created Region
+
+    """
+    from_point = view.text_point(span.fromLine - 1, span.fromColumn - 1)
+    to_point = view.text_point(span.toLine - 1, span.toColumn - 1)
+    return sublime.Region(from_point, to_point)
+
 def span_from_view_region(view, region):
     (from_line, from_col) = view.rowcol(region.begin())
     (to_line,   to_col)   = view.rowcol(region.end())
@@ -56,49 +74,3 @@ def span_from_view_region(view, region):
         "spanToLine": to_line + 1,
         "spanToColumn": to_col + 1
         }
-
-def get_keypath(a_dict, keypath):
-    """
-    Extracts a keypath from a nested dictionary, e.g.
-    >>> get_keypath({"hey":{"there":"kid"}}, ["hey", "there"])
-    'kid'
-    Returns None if the keypath doesn't exist.
-    """
-    value = a_dict
-    path = keypath
-    while value and path:
-        if not type(value) is dict: return None
-        value = value.get(path[0])
-        path = path[1:]
-    return value
-
-def module_name_for_view(view):
-    module_name = view.substr(view.find("^module [A-Za-z._]*", 0)).replace("module ", "")
-    return module_name
-
-def filter_enclosing(from_col, to_col, from_line, to_line, spans):
-    return [span for span in spans if
-        (   ((span[1].get("spanFromLine")<from_line) or
-            (span[1].get("spanFromLine") == from_line and
-             span[1].get("spanFromColumn") <= from_col))
-        and ((span[1].get("spanToLine")>to_line) or
-            (span[1].get("spanToLine") == to_line and
-             span[1].get("spanToColumn") >= to_col))
-        )]
-
-def type_info_for_sel(view,types):
-    """
-    Takes the type spans returned from a get_exp_types request and returns a
-    tuple (type_string,type_span) of the main expression
-    """
-    result = None
-    if view and types:
-        region = view.sel()[0]
-        (from_line_, from_col_) = view.rowcol(region.begin())
-        (to_line_, to_col_) = view.rowcol(region.end())
-        [type_string, type_span] = filter_enclosing(
-            from_col_+1, to_col_+1,
-            from_line_+1, to_line_+1,
-            types)[0]
-        result = (type_string, type_span)
-    return result


### PR DESCRIPTION
All parsing logic is moved into the response module and used for all stack-ide response handlers. 
Travis is configured to collect coverage and report it to a Coveralls.io account.
