### PR TITLE
use ctrl+shift on OS-X to avoid masking default ctrl+e and ctrl+d

### DIFF
--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -1,11 +1,11 @@
 [
 
-    { "keys": ["ctrl+e"], "command": "show_panel", "args": {"panel": "output.hide_errors"} },
-    { "keys": ["ctrl+i"], "command": "show_hs_info_at_cursor", "context": [
+    { "keys": ["ctrl+shift+e"], "command": "show_panel", "args": {"panel": "output.hide_errors"} },
+    { "keys": ["ctrl+shift+i"], "command": "show_hs_info_at_cursor", "context": [
          {"key": "selector", "operator": "equal", "operand": "source.haskell"}
        ]
     }
-,   { "keys": ["ctrl+d"], "command": "goto_definition_at_cursor", "context": [
+,   { "keys": ["ctrl+shift+d"], "command": "goto_definition_at_cursor", "context": [
          {"key": "selector", "operator": "equal", "operand": "source.haskell"}
        ]
     }


### PR DESCRIPTION
For https://github.com/lukexi/stack-ide-sublime/issues/18.
