### PR TITLE
type popup: colours + links to doc !

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -72,16 +72,31 @@ def within(smaller, larger):
 def filter_enclosing(view, region, span_pairs):
     return ((item, span) for item, span in span_pairs if within(region, view_region_from_span(view, span)))
 
-def shorten_module_prefixes(type_with_prefixes):
-    words = type_with_prefixes.replace("(", " ( ").replace("[", " [ ").split(' ')
-    return (" ".join(map(shorten_module_prefix, words)).replace(" ( ","(").replace(" [ ","["))
+def format_type(raw_type):
+    words = raw_type.replace("(", " ( ").replace("[", " [ ").split(' ')
+    return (" ".join(map(format_subtype, words)).replace(" ( ","(").replace(" [ ","["))
 
-def shorten_module_prefix(prefixed_type):
-    words = prefixed_type.split('.')
+def format_subtype(type_string):
+    # See documentation about popups here:
+    #       http://facelessuser.github.io/sublime-markdown-popups/usage/ (official doc)
+    # and   https://www.sublimetext.com/forum/viewtopic.php?f=2&t=17583  (html support announcment)
+
+    words = [x for x in type_string.split('.') if x != '']
+    # [x for x in type_string.split('.') is necessary to handle the `a.` part of `forall a.` properly
+
     if (len(words) > 1):
-        return ("_" + words[-1])
+        s = ("_"+words[-1])
     else:
-        return prefixed_type
+        s = type_string
+
+    if s == "->":
+        return ('<span style="color: blue">{0}</span>'.format("->"))
+    elif s == "(" or s == ")" or s == "[" or s == "]" or s=='':
+        return s
+    elif (s[0] != '_' and s[0].islower()):
+        return ('<span style="color: #4C4C4C">{0}</span>'.format(s))
+    else:
+        return ('<a href="http://www.stackage.org/lts/hoogle?q={0}" style="color: #333333">{1}</a>'.format(type_string, s))
 
 def is_haskell_view(view):
     return view.match_selector(view.sel()[0].begin(), "source.haskell")

--- a/win.py
+++ b/win.py
@@ -53,9 +53,9 @@ class Win:
                     view.show_popup(format_type(_type), on_navigate= (lambda href: webbrowser.open(href)))
                 return
 
-        # Clear type-at-cursor display     
-        for view in self.window.views():       
-            view.set_status("type_at_cursor", "")      
+        # Clear type-at-cursor display
+        for view in self.window.views():
+            view.set_status("type_at_cursor", "")
             view.add_regions("type_at_cursor", [], "storage.type", "", sublime.DRAW_OUTLINED)
 
 

--- a/win.py
+++ b/win.py
@@ -5,8 +5,9 @@ try:
     import sublime
 except ImportError:
     from test.stubs import sublime
-from utility import first_folder, view_region_from_span, filter_enclosing, shorten_module_prefixes
+from utility import first_folder, view_region_from_span, filter_enclosing, format_type
 from response import parse_source_errors, parse_exp_types
+import webbrowser
 
 class Win:
     """
@@ -49,7 +50,7 @@ class Win:
                 view.set_status("type_at_cursor", _type)
                 view.add_regions("type_at_cursor", [view_region_from_span(view, span)], "storage.type", "", sublime.DRAW_OUTLINED)
                 if Win.show_popup:
-                    view.show_popup(shorten_module_prefixes(_type))
+                    view.show_popup(format_type(_type), on_navigate= (lambda href: webbrowser.open(href)))
                 return
 
         # Clear type-at-cursor display     


### PR DESCRIPTION
There is now a `format_type` function that add  `colors` and `clickable links` to stack-ide string result.
`format_type` is only used in the automatic type popup for now.

![image](https://cloud.githubusercontent.com/assets/2150990/11168603/f8d7329e-8b96-11e5-94a8-075e1d7e5e72.png)

clicking on `middleware`
![image](https://cloud.githubusercontent.com/assets/2150990/11168614/92f97102-8b97-11e5-84c2-402ecaa3aef6.png)

open automatically the list of hoogle results for the `latest stackage`, and with the correct `module prefix hierarchy`! Yay

![image](https://cloud.githubusercontent.com/assets/2150990/11168612/7fb6b4b0-8b97-11e5-9c41-1851a45c50f0.png)
