### PR TITLE
Fix type search links

### DIFF
--- a/SublimeStackIDE.sublime-settings
+++ b/SublimeStackIDE.sublime-settings
@@ -9,4 +9,11 @@
   // If "show_popup" is true, a popup will appear right below selection
   // to show the type in addition to the text shown in the status bar
   ,"show_popup": false
+
+  // if show_popup is true, clicking on types displayed in the popup panel will
+  // open a web-browser at specified hoogle_url with the right type query.
+  // if you set this to your own hoogle webserver setup for your project,
+  // you'll be able to see the documentation for your own type
+  // example: "hoogle_url": "https://www.google.fr/search?q=what+is+haskell+"
+  ,"hoogle_url": "http://www.stackage.org/lts/hoogle?q="
 }

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 class Settings:
 
-    def __init__(self, verbosity, add_to_PATH, show_popup):
+    def __init__(self, verbosity, add_to_PATH, show_popup, hoogle_url):
         self.verbosity = verbosity
         self.add_to_PATH = add_to_PATH
         self.show_popup = show_popup
+        self.hoogle_url = hoogle_url

--- a/utility.py
+++ b/utility.py
@@ -96,7 +96,7 @@ def format_subtype(type_string):
     elif (s[0] != '_' and s[0].islower()):
         return ('<span style="color: #4C4C4C">{0}</span>'.format(s))
     else:
-        return ('<a href="http://www.stackage.org/lts/hoogle?q={0}" style="color: #333333">{1}</a>'.format(type_string.split(":")[-1], s))
+        return ('<a href="{0}" style="color: #333333">{1}</a>'.format(type_string.split(":")[-1], s))
 
 def is_haskell_view(view):
     return view.match_selector(view.sel()[0].begin(), "source.haskell")

--- a/utility.py
+++ b/utility.py
@@ -96,7 +96,7 @@ def format_subtype(type_string):
     elif (s[0] != '_' and s[0].islower()):
         return ('<span style="color: #4C4C4C">{0}</span>'.format(s))
     else:
-        return ('<a href="http://www.stackage.org/lts/hoogle?q={0}" style="color: #333333">{1}</a>'.format(type_string, s))
+        return ('<a href="http://www.stackage.org/lts/hoogle?q={0}" style="color: #333333">{1}</a>'.format(type_string.split(":")[-1], s))
 
 def is_haskell_view(view):
     return view.match_selector(view.sel()[0].begin(), "source.haskell")

--- a/utility.py
+++ b/utility.py
@@ -73,8 +73,8 @@ def filter_enclosing(view, region, span_pairs):
     return ((item, span) for item, span in span_pairs if within(region, view_region_from_span(view, span)))
 
 def format_type(raw_type):
-    words = raw_type.replace("(", " ( ").replace("[", " [ ").split(' ')
-    return (" ".join(map(format_subtype, words)).replace(" ( ","(").replace(" [ ","["))
+    words = raw_type.replace("(", " ( ").replace(")", " ) ").replace("[", " [ ").replace("]", " ] ").replace(",", " , ").split(' ')
+    return (" ".join(map(format_subtype, words)).replace(" ( ","(").replace(" ) ",")").replace(" [ ","[").replace(" ] ","]").replace(" , ",","))
 
 def format_subtype(type_string):
     # See documentation about popups here:

--- a/utility.py
+++ b/utility.py
@@ -91,7 +91,7 @@ def format_subtype(type_string):
 
     if s == "->":
         return ('<span style="color: blue">{0}</span>'.format("->"))
-    elif s == "(" or s == ")" or s == "[" or s == "]" or s=='':
+    elif s == "(" or s == ")" or s == "[" or s == "'" or s == "]" or s=='' or s==',':
         return s
     elif (s[0] != '_' and s[0].islower()):
         return ('<span style="color: #4C4C4C">{0}</span>'.format(s))

--- a/watchdog.py
+++ b/watchdog.py
@@ -27,6 +27,7 @@ def plugin_loaded():
     Log._set_verbosity(settings.verbosity)
     StackIDEManager.configure(settings)
     Win.show_popup = settings.show_popup
+    Win.hoogle_url = settings.hoogle_url
     watchdog = StackIDEWatchdog()
 
 def plugin_unloaded():
@@ -43,7 +44,8 @@ def load_settings():
     return Settings(
         settings_obj.get('verbosity', 'normal'),
         add_to_path if isinstance(add_to_path, list) else [],
-        settings_obj.get('show_popup', False)
+        settings_obj.get('show_popup', False),
+        settings_obj.get('hoogle_url', "http://www.stackage.org/lts/hoogle?q=")
     )
 
 def on_settings_changed():
@@ -58,6 +60,8 @@ def on_settings_changed():
         StackIDEManager.reset()
     elif updated_settings.show_popup != settings.show_popup:
         Win.show_popup = updated_settings.show_popup
+    elif updated_settings.hoogle_url != settings.hoogle_url:
+        Win.hoogle_url = updated_settings.hoogle_url
 
     settings = updated_settings
 

--- a/win.py
+++ b/win.py
@@ -50,7 +50,7 @@ class Win:
                 view.set_status("type_at_cursor", _type)
                 view.add_regions("type_at_cursor", [view_region_from_span(view, span)], "storage.type", "", sublime.DRAW_OUTLINED)
                 if Win.show_popup:
-                    view.show_popup(format_type(_type), on_navigate= (lambda href: webbrowser.open(href)))
+                    view.show_popup(format_type(_type), on_navigate= (lambda href: webbrowser.open(Win.hoogle_url + href)))
                 return
 
         # Clear type-at-cursor display


### PR DESCRIPTION
- [x] better type escaping (handle properly kinds `'` notation and nested types)
  ![image](https://cloud.githubusercontent.com/assets/2150990/11178668/793e24c6-8c4e-11e5-9d5c-82c5a807fbb5.png)
- [x] proper "packagename:Type.Prefix.Stuff" type handling
- [x] parametric hoogle url
